### PR TITLE
Fix spec to allow for students/student or just student path

### DIFF
--- a/spec/views/student_show_spec.rb
+++ b/spec/views/student_show_spec.rb
@@ -1,23 +1,27 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "show_view" do
-  let(:student){ Student.create(name: 'Bobby', hometown: Faker::Address.city, birthday: Faker::Date.between(from: 25.years.ago, to: 18.years.ago))}
+RSpec.describe 'show_view' do
+  before do
+    lookup_context.prefixes << 'students'
+  end
+  let(:student) { Student.create(name: 'Bobby', hometown: Faker::Address.city, birthday: Faker::Date.between(from: 25.years.ago, to: 18.years.ago)) }
 
-  it "renders student information from the classroom show view" do
+  it 'renders student information from the classroom show view' do
     assign(:student, student)
-    render :template => "students/show"
+    render template: 'students/show'
     expect(rendered).to include('Bobby')
   end
 
-  it "renders a students/student partial" do
+  it 'renders a students/student partial' do
     assign(:student, student)
-    render :template => "students/show"
-    expect(rendered).to render_template(:partial => "students/student", locals: {student: student})
+    render template: 'students/show'
+    expect(rendered).to render_template(partial: 'students/_student')
+      .or render_template(partial: '_student')
   end
 
-  it "displays the student information from the partial" do
+  it 'displays the student information from the partial' do
     assign(:student, student)
-    render :partial => "students/student", locals: {student: student}
-    expect(rendered).to match /Bobby/
+    render partial: 'students/student', locals: { student: student }
+    expect(rendered).to match(/Bobby/)
   end
 end


### PR DESCRIPTION
This pull request updates the `student_show_spec.rb` test file to improve consistency and reliability. The main changes include standardizing string quoting, updating partial rendering expectations, and ensuring the correct view context is set up for the tests.

Test improvements and consistency:

* Standardized all string quotes from double (`"`) to single (`'`) quotes for consistency throughout the file.
* Updated the partial rendering expectation in the test to allow for both `'students/_student'` and `'_student'` partials, making the test more robust to different rendering scenarios.
* Added a `before` block to append `'students'` to `lookup_context.prefixes`, ensuring the correct view context is used during rendering.
* Changed the hash syntax in `render` and `expect` calls to the newer Ruby style (e.g., `template: 'students/show'` instead of `:template => "students/show"`).
* Improved formatting in the expectation for matching rendered content, wrapping the string in parentheses for clarity.